### PR TITLE
Remove referencia do HEAD da branch no script de conversao de jupyter…

### DIFF
--- a/.github/workflows/convert_to_python_script.yml
+++ b/.github/workflows/convert_to_python_script.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
       - name: Configura o Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
O hook de converter de Jupyter Notebook pra Python falha no git fetch, como descrito no PR #39 .

Remover as duas linhas desse PR resolveu no caso do PR #24 , então criei esse PR pra poder fechar os outros PRs, como sugerido no #24 