### PR TITLE
Adiciona instrucao de instalacao do projeto

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Contribuições são muito bem-vindas. Veja como contribuir no nosso [Guia de Co
 Utilizamos a versão 3.8 do Python. Recomendamos fortemente o uso de _virtual environments_ para isolamento
 das dependências e prevenção de possíveis conflitos com dependências de outros projetos.
 
+Ao inicializar seu _virtual environment_, configure o projeto. Para isto, execute, na pasta do projeto, o seguinte comando:
+
+```
+python setup.py install
+```
+
 ### Dependências
 
 Para instalar as dependências, execute:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Contribuições são muito bem-vindas. Veja como contribuir no nosso [Guia de Co
 Utilizamos a versão 3.8 do Python. Recomendamos fortemente o uso de _virtual environments_ para isolamento
 das dependências e prevenção de possíveis conflitos com dependências de outros projetos.
 
-Ao inicializar seu _virtual environment_, configure o projeto. Para isto, execute, na pasta do projeto, o seguinte comando:
+Após inicializar seu _virtual environment_, configure o projeto. Para isto, execute, na pasta do projeto, o seguinte comando:
 
 ```
 python setup.py install

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ das dependências e prevenção de possíveis conflitos com dependências de out
 Após inicializar seu _virtual environment_, configure o projeto. Para isto, execute, na pasta do projeto, o seguinte comando:
 
 ```
-python setup.py install
+python setup.py develop
 ```
 
 ### Dependências


### PR DESCRIPTION
Adiciona instrução no README.md para executar o comando `python setup.py install` ao ativar o venv pela primeira vez. Pra ninguém reclamar dos imports do Python depois 8-)